### PR TITLE
Add ability to pass in file path as a CLI argument with sbt run

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,11 @@ A simple project to extract data from a CSV file for analytics
 >sbt test
 
 ## Run
->stb --error run
+Run with default data source file:
+>sbt --error run
+
+Run with custom data source file:
+>sbt --error "run [sourceFilePath]"
 
 # Requirements
 - [ ] Written in Scala/SBT

--- a/src/main/scala/csvreader/CSVReader.scala
+++ b/src/main/scala/csvreader/CSVReader.scala
@@ -1,9 +1,10 @@
 package csvreader
 
-import scala.collection.mutable.Map
+import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.io.BufferedSource
+import scala.util.{Try, Failure, Success}
 
 /** CSVReader
   * 
@@ -13,19 +14,30 @@ object CSVReader extends App {
   var sourcePath = "people.csv"
   if (args.length > 0)
     sourcePath = args(0)
-  val file = io.Source.fromFile(sourcePath) 
-  var m = Map[String, Int]()
-  for (line <- file.getLines) {
-    var state = line.split(",")(2)
-    if (m.contains(state)) {
-      m(state) += 1
-    } else {
-      m(state) = 1
-    }
+  val readFile = Try(io.Source.fromFile(sourcePath))
+  var m = mutable.Map[String, Int]()
+  readFile match {
+    case Success(file) => m = countStates(file)
+    case Failure(exception) => println("Please pass a valid source path with sbt \"run [sourcePath]\".")
   }
+  
   m.foreach(println)
 
   val future = Future {
     m.foreach(println)
-  } 
+  }
+
+  /** Returns a map of states with their associated counts. */
+  def countStates(file: BufferedSource): mutable.Map[String, Int] = {
+    var m = mutable.Map[String, Int]()
+    for (line <- file.getLines) {
+      var state = line.split(",")(2)
+      if (m.contains(state))
+        m(state) += 1
+      else
+        m(state) = 1
+    }
+
+    m
+  }
 }

--- a/src/main/scala/csvreader/CSVReader.scala
+++ b/src/main/scala/csvreader/CSVReader.scala
@@ -10,19 +10,22 @@ import scala.util.{Failure, Success}
   * 
   */
 object CSVReader extends App {
-    val file = io.Source.fromFile("people.csv") 
-    var m = Map[String, Int]()
-    for (line <- file.getLines) {
-      var state = line.split(",")(2)
-      if (m.contains(state)) {
-        m(state) += 1
-      } else {
-        m(state) = 1
-      }
+  var sourcePath = "people.csv"
+  if (args.length > 0)
+    sourcePath = args(0)
+  val file = io.Source.fromFile(sourcePath) 
+  var m = Map[String, Int]()
+  for (line <- file.getLines) {
+    var state = line.split(",")(2)
+    if (m.contains(state)) {
+      m(state) += 1
+    } else {
+      m(state) = 1
     }
-    m.foreach(println)
+  }
+  m.foreach(println)
 
-    val future = Future {
-      m.foreach(println)
-    } 
+  val future = Future {
+    m.foreach(println)
+  } 
 }


### PR DESCRIPTION
Syntax is sbt "run [sourcePath]".

Also checks that it's a valid path with a Try (Success and Failure) match block.